### PR TITLE
git logUse relative path for mondial.xml

### DIFF
--- a/HostedWpfApplication/HostedWpfApplication/appsettings.json
+++ b/HostedWpfApplication/HostedWpfApplication/appsettings.json
@@ -1,6 +1,6 @@
 {
   "title": "Titel aus Appsettings.json",
-  "MondialPath": "E:\\Projekte\\dotnetproBeispiele\\HostedWpfApplication\\HostedWpfApplication\\Data\\mondial.xml",
+  "MondialPath": "..\\..\\..\\Data\\mondial.xml",
 
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Using a relative path will ensure that the program works out-of-the-box on other machines that have a different folder structure.