### PR TITLE
Fehler in RemoveItem behoben  

### DIFF
--- a/WpfMvvmMultiselect/WpfMvvmMultiselect/Utilities/SelectableItemList.cs
+++ b/WpfMvvmMultiselect/WpfMvvmMultiselect/Utilities/SelectableItemList.cs
@@ -43,13 +43,22 @@ namespace WpfMvvmMultiselect.Utilities
     protected override void RemoveItem(int index)
     {
       // Handler wieder entfernen
-      this[index].IsSelectedChanged += Si_IsSelectedChanged;
+      this[index].IsSelectedChanged -= Si_IsSelectedChanged;
       base.RemoveItem(index);
     }
 
-    /// <summary>
-    /// Ausgewählte Elemente
-    /// </summary>
-    public IEnumerable<SelectableItem> SelectedItems => this.Where(i => i.IsSelected).ToList();
+        protected override void ClearItems()
+        {
+            foreach (var selectableItem in this)
+            {
+                selectableItem.IsSelectedChanged -= Si_IsSelectedChanged;
+            }
+            base.ClearItems();
+        }
+
+        /// <summary>
+        /// Ausgewählte Elemente
+        /// </summary>
+        public IEnumerable<SelectableItem> SelectedItems => this.Where(i => i.IsSelected).ToList();
   }
 }


### PR DESCRIPTION
Der Eventhandler in der RemoveItem() Methode wird nun entfernt..
Außerdem noch ein override der Clear() Methode um den Handler dort auch zu entfernen